### PR TITLE
Correcion DockerFile

### DIFF
--- a/src/ContactosAPI/Dockerfile
+++ b/src/ContactosAPI/Dockerfile
@@ -1,4 +1,5 @@
-FROM bitnami/dotnet-sdk:latest AS build 
+# FROM bitnami/dotnet-sdk:latest AS build 
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
 COPY ContactosAPI.csproj .
@@ -10,7 +11,8 @@ RUN dotnet build "ContactosAPI.csproj" -c Release -o /app/build
 
 RUN dotnet publish -c release -o /app
 
-FROM openeuler/dotnet-aspnet:8.0.10-oe2203sp4
+# FROM openeuler/dotnet-aspnet:8.0.10-oe2203sp4
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 WORKDIR /app
 
 COPY --from=build /app .


### PR DESCRIPTION
This pull request updates the `Dockerfile` for the `ContactosAPI` project to use official Microsoft .NET images instead of Bitnami and openEuler images. These changes ensure compatibility with the latest .NET SDK and runtime versions.

Updates to base images:

* [`src/ContactosAPI/Dockerfile`](diffhunk://#diff-f313d202b4b524e470837329407e4f3a06202813a059b2fb67873bfc00f6bb75L1-R2): Changed the build image from `bitnami/dotnet-sdk:latest` to `mcr.microsoft.com/dotnet/sdk:8.0` for building the project.
* [`src/ContactosAPI/Dockerfile`](diffhunk://#diff-f313d202b4b524e470837329407e4f3a06202813a059b2fb67873bfc00f6bb75L13-R15): Changed the runtime image from `openeuler/dotnet-aspnet:8.0.10-oe2203sp4` to `mcr.microsoft.com/dotnet/aspnet:8.0` for running the application.